### PR TITLE
[impl] add DefOrRef and variant-aware get_element

### DIFF
--- a/include/sodf/components/def_or_ref.h
+++ b/include/sodf/components/def_or_ref.h
@@ -1,0 +1,34 @@
+#ifndef SODF_COMPONENTS_DEF_OR_REF_H_
+#define SODF_COMPONENTS_DEF_OR_REF_H_
+
+#include <string>
+#include <variant>
+
+namespace sodf {
+namespace components {
+
+/// A lightweight "inline definition OR alias id" container.
+///
+/// Usage pattern:
+///   - Definition-store components can use:
+///       elements: ElementMap<std::string, DefOrRef<T>>
+///
+///   - The map key is the element ID.
+///     By your convention, this ID is also the frame ID in TransformComponent.
+///
+///   - If value holds T:
+///       → inline definition
+///     If value holds std::string:
+///       → alias to a definition ID (local or library)
+///
+/// NOTE:
+///   In this header, alias resolution is LOCAL ONLY:
+///   the string is treated as another key in the same component's elements.
+///
+template <class T>
+using DefOrRef = std::variant<T, std::string>;
+
+}  // namespace components
+}  // namespace sodf
+
+#endif  // SODF_COMPONENTS_DEF_OR_REF_H_

--- a/include/sodf/components/shape.h
+++ b/include/sodf/components/shape.h
@@ -2,28 +2,42 @@
 #define SODF_COMPONENTS_SHAPE_H_
 
 #include <sodf/components/data_type.h>
+#include <sodf/components/def_or_ref.h>
 #include <sodf/geometry/shape.h>
-
-#include <vector>
-#include <utility>
-
-#include <Eigen/Geometry>
 
 namespace sodf {
 namespace components {
 
-// Forward declaration
+/// Stores reusable Shape definitions OR aliases to them.
+///
+/// Element key conventions:
+///   - Keys may represent either:
+///       (a) definition IDs  (e.g. "shape/well")
+///       (b) instance IDs    (e.g. "shape/well/A1")
+///
+/// Value meaning:
+///   - DefOrRef<Shape> holds:
+///       - geometry::Shape         → inline definition
+///       - std::string (id)        → alias to definition ID
+///
+/// Placement:
+///   - For instance keys, placement is found in TransformComponent
+///     element with the same key (your global convention).
 struct ShapeComponent
 {
-  ElementMap<std::string, geometry::Shape> elements;
+  using definition_type = geometry::Shape;
+  ElementMap<std::string, DefOrRef<definition_type>> elements;
 };
 
+/// Stores reusable StackedShape definitions OR aliases to them.
+/// Same conventions as ShapeComponent.
 struct StackedShapeComponent
 {
-  ElementMap<std::string, geometry::StackedShape> elements;
+  using definition_type = geometry::StackedShape;
+  ElementMap<std::string, DefOrRef<definition_type>> elements;
 };
 
 }  // namespace components
 }  // namespace sodf
 
-#endif
+#endif  // SODF_COMPONENTS_SHAPE_H_

--- a/include/sodf/database/registry_p.h
+++ b/include/sodf/database/registry_p.h
@@ -64,15 +64,29 @@ public:
     return traits::template has<C>(impl_, e);
   }
   template <class C>
+  bool has(entity_type e) const
+  {
+    return traits::template has<C>(const_cast<Backend&>(impl_), e);
+  }
+
+  template <class C>
   C* get(entity_type e)
   {
     return traits::template get<C>(impl_, e);
   }
   template <class C>
-  const C* get_const(entity_type e) const
+  const C* get(entity_type e) const
   {
     return traits::template get<C>(const_cast<Backend&>(impl_), e);
   }
+
+  // You can keep get_const if you like, but it's now redundant.
+  template <class C>
+  const C* get_const(entity_type e) const
+  {
+    return get<C>(e);
+  }
+
   template <class C>
   C* get_or_add(entity_type e)
   {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 set(SODF_TESTS
     test_database.cpp
+    test_database_diff.cpp
     test_fluid_domain_shape.cpp
     test_fluid_domain_convex_mesh_shape.cpp
     test_uri_resolver.cpp
     test_xml_parser.cpp
     test_expression_parser.cpp
     test_patch_operations.cpp
-    test_database_diff.cpp
 )
 
 set(TEST_DEPENDECIES


### PR DESCRIPTION
Introduces DefOrRef<T> for inline defs vs local aliases, updates shape components to store variants, and adds variant-aware get_element with local-only alias resolution across Database/Diff.